### PR TITLE
Fix scraping via proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ Para correr la aplicacion:
 python trebol.py
 ```
 El archivo `trebol.log` se actualizará con información de la ejecución.
+Si `pystray` está instalado, la aplicación mostrará un ícono en el área de
+notificación para permitir minimizar y restaurar la ventana.
+La página de resultados utiliza Cloudflare, por lo que el programa
+descarga las versiones en texto mediante `https://r.jina.ai/` para poder
+extraer la información.
 
 ## Crear ejecutable
 


### PR DESCRIPTION
## Summary
- use r.jina.ai to fetch TuJugada pages in plain text
- parse Loto Plus and Quiniela using regex
- document Cloudflare proxy requirement

## Testing
- `python -m py_compile trebol.py`

------
https://chatgpt.com/codex/tasks/task_e_685773ae4fd883288f3db3a343133b51