### PR TITLE
Improve Trebol UI and manual check

### DIFF
--- a/trebol.py
+++ b/trebol.py
@@ -2,7 +2,6 @@ import json
 import logging
 import os
 import threading
-import time
 import tkinter as tk
 from tkinter import messagebox
 from datetime import datetime
@@ -20,7 +19,6 @@ except Exception:
     from tkinter import ttk
 
 import requests
-from bs4 import BeautifulSoup
 import re
 
 try:
@@ -47,43 +45,50 @@ class TrebolApp:
         logging.info('TrebolApp initialized')
         self.create_widgets()
         self.load_user_data()
-        self.running = True
         self.previous_results = None
-        self.update_thread = threading.Thread(target=self.update_loop, daemon=True)
-        self.update_thread.start()
         if HAS_TRAY:
             self.setup_tray()
 
     def create_widgets(self):
-        frame = ttk.Frame(self.root, padding=10)
-        frame.pack(padx=10, pady=10)
+        big_font = ("Helvetica", 16)
 
-        ttk.Label(frame, text='Loto Plus (6 numeros):').grid(row=0, column=0, sticky='w')
-        self.loto_entry = ttk.Entry(frame, width=30)
-        self.loto_entry.grid(row=0, column=1, padx=5, pady=2)
+        self.loto_frame = tk.Frame(self.root, bg="red", padx=10, pady=10)
+        self.loto_frame.pack(fill="x", padx=10, pady=5)
 
-        ttk.Label(frame, text='Numero Plus:').grid(row=1, column=0, sticky='w')
-        self.plus_entry = ttk.Entry(frame, width=30)
-        self.plus_entry.grid(row=1, column=1, padx=5, pady=2)
+        tk.Label(self.loto_frame, text="Loto Plus", bg="red", fg="white", font=("Helvetica", 18, "bold")).grid(row=0, column=0, columnspan=7, pady=5)
+        self.loto_entries = []
+        for i in range(6):
+            e = tk.Entry(self.loto_frame, width=3, font=big_font, justify="center")
+            e.grid(row=1, column=i, padx=3, pady=5)
+            self.loto_entries.append(e)
+        self.plus_entry = tk.Entry(self.loto_frame, width=2, font=big_font, justify="center")
+        self.plus_entry.grid(row=1, column=6, padx=3, pady=5)
+        self.loto_info = tk.Label(self.loto_frame, text="", bg="red", fg="white", font=big_font)
+        self.loto_info.grid(row=2, column=0, columnspan=7, pady=5)
 
-        ttk.Label(frame, text='Quiniela (hasta 3 numeros):').grid(row=2, column=0, sticky='w')
-        self.qui_entry = ttk.Entry(frame, width=30)
-        self.qui_entry.grid(row=2, column=1, padx=5, pady=2)
+        self.quini_frame = tk.Frame(self.root, bg="light grey", padx=10, pady=10)
+        self.quini_frame.pack(fill="both", expand=True, padx=10, pady=5)
+        tk.Label(self.quini_frame, text="Quiniela", bg="light grey", font=("Helvetica", 18, "bold")).grid(row=0, column=0, sticky="w")
+        self.qui_entry = tk.Entry(self.quini_frame, width=20, font=big_font)
+        self.qui_entry.grid(row=1, column=0, sticky="w", pady=5)
+        self.text = tk.Text(self.quini_frame, width=60, height=10, font=("Helvetica", 14))
+        self.text.grid(row=2, column=0, pady=5)
 
+        btn_frame = ttk.Frame(self.root, padding=10)
+        btn_frame.pack()
         btn_style = 'primary.TButton' if tb else 'TButton'
         danger_style = 'danger.TButton' if tb else 'TButton'
-        self.save_btn = ttk.Button(frame, text='Guardar', command=self.save_user_data, style=btn_style)
-        self.save_btn.grid(row=3, column=0, pady=5)
-        self.update_btn = ttk.Button(frame, text='Actualizar', command=self.scrape_once, style=btn_style)
-        self.update_btn.grid(row=3, column=1, pady=5)
-        self.exit_btn = ttk.Button(frame, text='Cerrar aplicacion', command=self.on_close, style=danger_style)
-        self.exit_btn.grid(row=4, column=0, columnspan=2, pady=5)
+        self.check_btn = ttk.Button(btn_frame, text='Checkeá mi jugada', command=self.scrape_once, style=btn_style)
+        self.check_btn.pack(side='left', padx=5)
+        self.exit_btn = ttk.Button(btn_frame, text='Salir', command=self.on_close, style=danger_style)
+        self.exit_btn.pack(side='left', padx=5)
 
-        self.text = tk.Text(self.root, width=60, height=20)
-        self.text.pack(padx=10, pady=10)
+        self.status_var = tk.StringVar(value='Listo')
+        self.status_label = ttk.Label(self.root, textvariable=self.status_var, anchor='w')
+        self.status_label.pack(fill='x', padx=5, pady=5)
 
         if tb:
-            for btn in (self.save_btn, self.update_btn, self.exit_btn):
+            for btn in (self.check_btn, self.exit_btn):
                 btn.bind('<Enter>', lambda e, b=btn: b.state(['hover']))
                 btn.bind('<Leave>', lambda e, b=btn: b.state(['!hover']))
 
@@ -107,15 +112,23 @@ class TrebolApp:
         self.root.after(0, self.root.lift)
 
     def load_user_data(self):
-        if os.path.isfile(USERS_FILE):
-            with open(USERS_FILE, 'r', encoding='utf-8') as f:
-                data = json.load(f)
-            self.loto_entry.insert(0, ','.join(map(str, data.get('loto', []))))
-            self.plus_entry.insert(0, str(data.get('plus', '')))
-            self.qui_entry.insert(0, ','.join(data.get('quiniela', [])))
+        if not os.path.isfile(USERS_FILE):
+            return
+        with open(USERS_FILE, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+        loto = data.get('loto', [])
+        for entry, val in zip(self.loto_entries, loto):
+            entry.insert(0, str(val).zfill(2))
+        if 'plus' in data and data['plus'] is not None:
+            self.plus_entry.insert(0, str(data['plus']))
+        self.qui_entry.insert(0, ','.join(data.get('quiniela', [])))
 
     def save_user_data(self):
-        loto = [int(n) for n in self.loto_entry.get().split(',') if n.strip().isdigit()]
+        loto = []
+        for e in self.loto_entries:
+            v = e.get().strip()
+            if v.isdigit():
+                loto.append(int(v))
         plus = int(self.plus_entry.get()) if self.plus_entry.get().isdigit() else None
         qui_raw = [q.strip() for q in self.qui_entry.get().split(',') if q.strip()]
         quiniela = [q.zfill(4) if len(q)<4 else q[-4:] for q in qui_raw][:3]
@@ -123,35 +136,55 @@ class TrebolApp:
         with open(USERS_FILE, 'w', encoding='utf-8') as f:
             json.dump(data, f)
         logging.info('User data saved')
-        messagebox.showinfo('Trebol', 'Datos guardados')
 
     def scrape_once(self):
         logging.info('Starting manual update')
+        self.status_var.set('Buscando los resultados en TuJugada.com...')
+        self.root.update_idletasks()
         loto_results = self.fetch_loto()
         quiniela_results = self.fetch_quiniela()
+        self.status_var.set('Analizando resultados...')
+        self.root.update_idletasks()
         self.compare_and_display(loto_results, quiniela_results)
-
-    def update_loop(self):
-        while self.running:
-            logging.info('Checking for updates')
-            self.scrape_once()
-            time.sleep(15)
+        self.save_user_data()
+        self.status_var.set('Listo')
 
     def fetch_loto(self):
         """Scrape Loto Plus results using a text proxy."""
         url = 'https://r.jina.ai/https://www.tujugada.com.ar/loto.asp'
         try:
             logging.info('Fetching Loto Plus results')
-            r = requests.get(url, headers={'User-Agent': 'Mozilla/5.0'})
-            text = r.text
+            text = requests.get(url, headers={'User-Agent': 'Mozilla/5.0'}).text
             results = {}
+            header = re.search(r"LOTO PLUS Nro: (\d+) - ([0-9/]+)", text)
+            if header:
+                results['sorteo'] = header.group(1)
+                results['fecha'] = header.group(2)
+            tokens = text.split('**')
             modalidades = ['TRADICIONAL', 'MATCH', 'DESQUITE', 'SALE O SALE']
             for moda in modalidades:
-                m = re.search(rf"\*\*{moda}\*\*(.*?)\*\*PREMIOS", text, re.S)
-                if m:
-                    nums = re.findall(r'\d+', m.group(1))[:6]
-                    results[moda.capitalize()] = [int(n) for n in nums]
-            plus_match = re.search(r"\*\*N\u00famero plus:\*\*\s*\*\*(\d+)\*\*", text)
+                try:
+                    idx = tokens.index(moda)
+                except ValueError:
+                    continue
+                numbers = []
+                i = idx + 1
+                while i < len(tokens) and len(numbers) < 6:
+                    t = tokens[i].strip()
+                    if t.isdigit():
+                        numbers.append(int(t))
+                    i += 1
+                info = {'numeros': numbers}
+                try:
+                    j = tokens.index(f'PREMIOS SORTEO {moda}')
+                    status = tokens[j + 10].strip()
+                    pozo = tokens[j + 12].strip()
+                    info['ganadores'] = status
+                    info['pozo'] = pozo
+                except ValueError:
+                    pass
+                results[moda.capitalize()] = info
+            plus_match = re.search(r"N\u00famero plus:\*\*\s*\*\*(\d+)\*\*", text)
             if plus_match:
                 results['Plus'] = int(plus_match.group(1))
             logging.info('Fetched Loto Plus results successfully')
@@ -190,17 +223,59 @@ class TrebolApp:
         self.text.delete('1.0', tk.END)
         now = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
         self.text.insert(tk.END, f'Actualizacion: {now}\n')
-        self.text.insert(tk.END, '--- Loto Plus ---\n')
-        user_data = self.load_from_file()
         logging.info('Displaying results')
+
         if 'error' in loto_results:
             self.text.insert(tk.END, f"Error al obtener Loto: {loto_results['error']}\n")
-        else:
-            for moda, nums in loto_results.items():
-                if moda=='Plus':
-                    self.text.insert(tk.END, f'Plus: {nums}\n')
+            return
+
+        sorteo = loto_results.get('sorteo', '')
+        fecha = loto_results.get('fecha', '')
+        trad = loto_results.get('Tradicional', {})
+        status = ''
+        if trad:
+            gan = trad.get('ganadores', '')
+            pozo = trad.get('pozo', '')
+            status = f'GANADORES : {gan} | POZO: {pozo}'
+        self.loto_info.config(text=f'Sorteo {sorteo} - {fecha} {status}')
+
+        result_numbers = trad.get('numeros', [])
+        plus_num = loto_results.get('Plus')
+
+        for e in self.loto_entries:
+            e.config(bg='white', fg='black')
+        self.plus_entry.config(bg='white', fg='black')
+
+        for e in self.loto_entries:
+            val = e.get().strip()
+            if val.isdigit():
+                n = int(val)
+                if n in result_numbers:
+                    e.config(bg='green', fg='white')
                 else:
-                    self.text.insert(tk.END, f'{moda}: {nums}\n')
+                    e.config(bg='red', fg='white')
+
+        val = self.plus_entry.get().strip()
+        if val.isdigit() and plus_num is not None:
+            if int(val) == plus_num:
+                self.plus_entry.config(bg='green', fg='white')
+            else:
+                self.plus_entry.config(bg='red', fg='white')
+
+        self.text.insert(tk.END, '--- Loto Plus ---\n')
+        for moda, info in loto_results.items():
+            if moda in ('sorteo', 'fecha', 'Plus'):
+                continue
+            nums = info.get('numeros', [])
+            gan = info.get('ganadores', '')
+            pozo = info.get('pozo', '')
+            line = f"{moda}: {nums}"
+            if gan or pozo:
+                line += f" | GANADORES: {gan} | POZO: {pozo}"
+            self.text.insert(tk.END, line + '\n')
+        if plus_num is not None:
+            self.text.insert(tk.END, f'Plus: {plus_num}\n')
+
         self.text.insert(tk.END, '\n--- Quiniela ---\n')
         if 'error' in quiniela_results:
             self.text.insert(tk.END, f"Error al obtener Quiniela: {quiniela_results['error']}\n")
@@ -232,7 +307,6 @@ class TrebolApp:
 
     def on_close(self, *args, **kwargs):
         logging.info('Application closing')
-        self.running = False
         if HAS_TRAY and hasattr(self, 'tray_icon'):
             self.tray_icon.stop()
         self.root.destroy()


### PR DESCRIPTION
## Summary
- redesign widgets with larger font and color-coded sections
- only provide two buttons: `Checkeá mi jugada` and `Salir`
- highlight hits and misses with green/red background
- fetch Loto Plus draw info and display draw number, date and pot status
- show progress in status bar and stop automatic scraping

## Testing
- `python -m py_compile trebol.py`

------
https://chatgpt.com/codex/tasks/task_e_68577ec76d448328be8edee6a9774b5a