### PR TITLE
Remove quiniela and refresh UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Trebol
 
-Aplicacion de escritorio para consultar resultados de Loto Plus y Quiniela.
+Aplicacion de escritorio para consultar resultados de Loto Plus.
 
 La interfaz ahora utiliza `ttkbootstrap` para un estilo moderno y
 animaciones de hover en los botones.


### PR DESCRIPTION
## Summary
- drop all Quiniela references
- enlarge window and widgets
- add spinner during scraping
- show next draw date and move Número Plus
- update README

## Testing
- `python -m py_compile trebol.py`
- `pip install -r requirements.txt` *(passed)*
- `python trebol.py` *(failed: no display)*

------
https://chatgpt.com/codex/tasks/task_e_68581d324e288328a9b03eee0e203891